### PR TITLE
Add custom handler

### DIFF
--- a/test/sidekiq_memlimit.rb
+++ b/test/sidekiq_memlimit.rb
@@ -5,15 +5,19 @@ require "#{File.dirname(__FILE__)}/../lib/sidekiq_memlimit"
 
 class TestSidekiqMemlimit < MiniTest::Unit::TestCase
   def test_rss_kb
+    SidekiqMemlimit.setup
     SidekiqMemlimit.run_gc
     kb = SidekiqMemlimit.rss_kb
     assert(kb > 0)
     assert_equal "VmRSS:\t%8d kB\n" % kb,
                  File.read("/proc/#{$$}/status").lines.grep(/VmRSS/).first
+    SidekiqMemlimit.stop_monitorthread
   end
 
   def test_monitorthread
+    SidekiqMemlimit.setup
     assert SidekiqMemlimit.monitorthread
+    SidekiqMemlimit.stop_monitorthread
   end
   
   def test_signal
@@ -21,11 +25,27 @@ class TestSidekiqMemlimit < MiniTest::Unit::TestCase
     trap("USR1") { received_signal = true }
     Sidekiq.logger = nil
     assert_equal false, received_signal
+    SidekiqMemlimit.setup
     
     # now take up >100MB memory
     x = 'a' * (101 * 1024 * 1024)
     
     sleep 1.1
     assert_equal true, received_signal
+    SidekiqMemlimit.stop_monitorthread
+  end
+
+  def test_custom_handler
+    handler_fired = false
+    Sidekiq.logger = nil
+    SidekiqMemlimit.setup { handler_fired = true }
+    assert_equal false, handler_fired
+
+    # now take up >100MB memory
+    x = 'a' * (101 * 1024 * 1024)
+
+    sleep 1.1
+    assert_equal true, handler_fired
+    SidekiqMemlimit.stop_monitorthread
   end
 end


### PR DESCRIPTION
Add custom handler of out of memory condition.  Done by passing proc to setup:

```
SidekiqMemlimit.setup do |pid|
  Rails.logger.info("Sidekiq over memory limit")
  Process.kill('TERM', pid)
  Thread.exit
end
```

Default behavior is unchanged - to signal USR1 and exit the monitor thread.  Required an explicit call to setup - thus removing the automatic call on load.

Updated tests for custom handling.  Also added ability to wait on the monitor thread to exit
